### PR TITLE
add `checkout` method to `ExternalRepository`

### DIFF
--- a/{{cookiecutter.project_name}}/scripts/helpers_for_setup/buddy/buddy/git_classes.py
+++ b/{{cookiecutter.project_name}}/scripts/helpers_for_setup/buddy/buddy/git_classes.py
@@ -4,6 +4,8 @@ copied into a given file-path.
 """
 
 import os
+import sys
+
 import sh
 
 
@@ -77,15 +79,21 @@ class ExternalRepository:
         Clone the requested repository into the directory `output_path` and
         ensure that the requested `commit` is checked out
         """
-        sh.git("clone", self.input_path, self.output_path)
+        if not self.local_exists():
+            sh.git("clone", self.input_path, self.output_path)
         # TODO:
-        # check if output directory is occupied
-        # if it is:
+        # if output dir is occupied:
         # - check that the sha-1 hash matches the wanted commit
         #   and throw an exception if it doesn't
         # otherwise:
-        # - check that the URL exists
-        # - clone from the URL to a temp directory
+        # - try to clone from the URL to a temp directory
         # - checkout the requested commit (throw exception if it
         #   doesn't exist)
         # - move from the temp directory to output
+
+    def checkout(self):
+        try:
+            sh.git("-C", self.output_path, "checkout", self.commit)
+        except Exception as e:
+            print(e)
+            sys.exit(1)

--- a/{{cookiecutter.project_name}}/scripts/helpers_for_setup/buddy/buddy/setup_git_clones.py
+++ b/{{cookiecutter.project_name}}/scripts/helpers_for_setup/buddy/buddy/setup_git_clones.py
@@ -48,6 +48,7 @@ def run_workflow(yaml_file):
     repositories = import_repository_details(yaml_file)
     for _, repo in repositories.items():
         repo.clone()
+        repo.checkout()
 
 
 def define_command_arg_parser():

--- a/{{cookiecutter.project_name}}/scripts/helpers_for_setup/buddy/tests/unit_tests/test_git_classes.py
+++ b/{{cookiecutter.project_name}}/scripts/helpers_for_setup/buddy/tests/unit_tests/test_git_classes.py
@@ -1,10 +1,8 @@
 import os
 import sh
 
-from mock import mock_open, patch
-
+from pytest_mock import mocker
 from buddy.git_classes import ExternalRepository, LocalRepository
-
 from tests.unit_tests.data_for_tests import repo_data1, repo_data2
 
 
@@ -42,7 +40,46 @@ class TestGitClone(object):
     def test_clone_when_no_local_copy(self, mocker):
         # note that we can't patch the function `sh.git.clone`
         mocker.patch("sh.git")
+        mocker.patch("os.path.exists", return_value=False)
         repo = ExternalRepository(*repo_data1())
-        assert not os.path.exists(repo.output_path)
         repo.clone()
         sh.git.assert_called_once_with("clone", repo.input_path, repo.output_path)
+
+    def test_no_clone_when_local_copy_exists(self, mocker):
+        mocker.patch("sh.git")
+        mocker.patch("os.path.exists", return_value=True)
+        repo = ExternalRepository(*repo_data1())
+        repo.clone()
+        sh.git.assert_not_called()
+
+
+class TestGitCommit(object):
+    def test_git_checkout_is_called(self, mocker):
+        mocker.patch("sh.git")
+        repo = ExternalRepository(*repo_data1())
+        repo.checkout()
+        sh.git.assert_called_once_with("-C", repo.output_path, "checkout", repo.commit)
+
+
+# How do we test that a specific commit of a git repo can be checked out?
+# - Unit tests with mocking:
+#   - patch sh.git; patch os.path.exists
+#   - check that sh.git("checkout", "-C", output_dir, commit) is called
+# - But the unit test just replicates the implementation, so really...
+# - Require integration tests for this:
+#    - Test1:
+#      - open temp dir
+#      - git init within the temp dir
+#      - git commit within the initialised dir
+#      - assert that an exception is thrown when trying to checkout a commit
+#    other than the hash for the only commit
+#    - Test2:
+#      - open temp dir
+#      - git init within the temp dir
+#      - git commit within the initialised dir
+#        - first commit adds file1
+#        - second commit adds file2
+#      - assert that both file1 and file2 exist
+#      - obtain the hash for the first commit
+#      - checkout the first commit
+#      - assert that file1 exists and file2 doesn't


### PR DESCRIPTION
Permits user to checkout a specific commit for a given repository once it has
been cloned. The program is killed if any exceptions are thrown, eg, if the
requested commit doesn't define a valid commit in the repository.

A unit test was added that checks that appropriate git commands are called by
python. But, this test only replicates the implementation of repo.checkout().

TODO: add integration tests that check that an error occurs when checking out
an invalid commit, and that checking out a valid commit leaves the file
structure in the correct state.

run_workflow (in setup_git_clones) was updated to ensure that repo.checkout()
is called.