### PR TITLE
fix #9 : prompt for R env and pkg flags

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,9 @@
 {
     "project_name": "my_new_project",
     "author_name": "Russell Hyde",
-    "conda_env": "{{ cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_') }}"
+    "conda_env": "{{ cookiecutter.project_name|lower|replace(' ', '_')|replace('-', '_') }}",
+    "is_r_required": 1,
+    "is_r_pkg_required": "{{ cookiecutter.is_r_required }}",
+    "r_pkg_name": "{{ cookiecutter.project_name|lower|replace(' ', '.')|replace('-', '.') }}",
+    "is_jupyter_r_kernel_required": 0
 }

--- a/{{cookiecutter.project_name}}/.setup_config/job_specific_vars.sh
+++ b/{{cookiecutter.project_name}}/.setup_config/job_specific_vars.sh
@@ -10,8 +10,9 @@
 # IS_R_REQUIRED=1 is required if an R kernel is to be made or R is to be used
 # IS_R_PKG_REQUIRED=1 is additionally required if an R package is to be made
 export JOBNAME="{{cookiecutter.project_name}}"
-export IS_R_REQUIRED=
-export IS_R_PKG_REQUIRED=
+export IS_R_REQUIRED={{cookiecutter.is_r_required}}
+export IS_R_PKG_REQUIRED={{cookiecutter.is_r_pkg_required}}
+export IS_JUPYTER_R_REQUIRED={{cookiecutter.is_jupyter_r_kernel_required}}
 
 # Nonessential variables:
 #
@@ -28,7 +29,7 @@ export PKGNAME=`echo "${JOBNAME}" | sed s/_/./g`
 export ENVNAME="{{cookiecutter.conda_env}}"
 
 ###############################################################################
-if [[ -n "${IS_R_REQUIRED}" ]] && [[ ${IS_R_REQUIRED} -ne 0 ]];
+if [[ ! -z "${IS_JUPYTER_R_REQUIRED}" ]] && [[ ${IS_JUPYTER_R_REQUIRED} -ne 0 ]];
 then
   export R_KERNEL="conda-env-${ENVNAME}-r"
 fi

--- a/{{cookiecutter.project_name}}/scripts/setup.sh
+++ b/{{cookiecutter.project_name}}/scripts/setup.sh
@@ -116,7 +116,7 @@ fi
 # - Ensure the R kernel for this project can be accessed by jupyter nbconvert
 # and within jupyter by adding it to the kernelspec list
 #
-if [[ ${IS_R_REQUIRED} -eq 1 ]];
+if [[ ${IS_JUPYTER_R_REQUIRED} -ne 0 ]];
 then
   if [[ -z "${R_KERNEL}" ]];
   then


### PR DESCRIPTION
Project startup code now asks whether:

- R is required

- an R package is required

- what the R package should be called

- whether a jupyter R kernel is required

Export and install of a jupyter R kernel is now determined by the latter.