### PR TITLE
fix #26 : use cookiecutter-defined R package name

### DIFF
--- a/{{cookiecutter.project_name}}/.setup_config/job_specific_vars.sh
+++ b/{{cookiecutter.project_name}}/.setup_config/job_specific_vars.sh
@@ -25,7 +25,11 @@ export R_INCLUDES_FILE="${PWD}/lib/conf/include_into_rpackage.txt"
 #   adds some files to the subdirectories ./lib/local_rfuncs/R or
 #   ./lib/global_rfuncs
 #
-export PKGNAME=`echo "${JOBNAME}" | sed s/_/./g`
+if [[ ! -z "${IS_R_PKG_REQUIRED}" ]] && [[ ${IS_R_PKG_REQUIRED} -ne 0 ]];
+then
+  export PKGNAME="{{cookiecutter.r_pkg_name}}"
+fi
+
 export ENVNAME="{{cookiecutter.conda_env}}"
 
 ###############################################################################


### PR DESCRIPTION
In previous code, cookiecutter was used to define R-package name. But the r-package name was not then passed into job_sepcific_vars.sh
This fixes that problem.
