### PR TITLE
fix #45 : add file-not-found error to md5sum

### DIFF
--- a/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_classes.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_classes.py
@@ -1,5 +1,4 @@
-import sys
-
+import os
 import sh
 
 
@@ -25,6 +24,8 @@ def get_md5sum(filepath):
     try:
         md5 = str(sh.md5sum(filepath)).strip().split()[0]
         return md5
-    except Exception:
-        raise
-        sys.exit(1)
+    except sh.ErrorReturnCode:
+        if isinstance(filepath, str) and not os.path.isfile(filepath):
+            raise FileNotFoundError(filepath)
+        else:
+            raise

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validation_classes.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validation_classes.py
@@ -25,8 +25,16 @@ class TestMd5sum(object):
             assert get_md5sum(f_non_empty) != empty_string_md5
         pass
 
+    def test_md5sum_fails_for_file_objects(self, tmpdir):
+        # user must provide a file-name, not a file-object
+        with sh.pushd(tmpdir):
+            f0 = open("file_name", mode="w")
+            with pytest.raises(Exception):
+                get_md5sum(f0)
+
     def test_md5sum_for_missing_file(self, tmpdir):
+        # a file should exist for any file-name passed in
         with sh.pushd(tmpdir):
             f0 = "missing_file"
-            with pytest.raises(Exception):
+            with pytest.raises(FileNotFoundError):
                 get_md5sum(f0)


### PR DESCRIPTION
For missing files, the previous version threw `sh` derived error/exception
messages that weren't very informative.

Now checks if the filename passed to get_md5sum is a valid file and throws
file-not-found error instead.

Checks that error is thrown when a file-object is passed to `get_md5sum`, rather than a file-name