### PR TITLE
fix #43 : prefix report failures with [FAILURE]

### DIFF
--- a/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_workflow.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_workflow.py
@@ -45,6 +45,7 @@ class ValidationWorkflow:
         def format_single_failure(validator):
             return "\t".join(
                 [
+                    "[FAILURE]",
                     "test_name:{}".format(validator.test_name),
                     "test_type:{}".format(validator.test_type),
                     "input_file:{}".format(validator.input_file),

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/unit_tests/test_validation_workflow.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/unit_tests/test_validation_workflow.py
@@ -143,7 +143,12 @@ class TestValidationReportFormatting(object):
         validator_dict = single_md5sum_validator()
         workflow = ValidationWorkflow(validator_dict)
         report = "\t".join(
-            ["test_name:my_test", "test_type:md5sum", "input_file:some_file"]
+            [
+                "[FAILURE]",
+                "test_name:my_test",
+                "test_type:md5sum",
+                "input_file:some_file",
+            ]
         )
         assert report == workflow.format_failure_report()
 


### PR DESCRIPTION
The failures in the validation tests weren't very explicit, so I added

`[FAILURE]`

as a prefix to the report that explains all failure cases.