### PR TITLE
fix #42 : nothing is printed when no report is needed

### DIFF
--- a/{{cookiecutter.project_name}}/bin/buddy/buddy/validate_file_contents.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/buddy/validate_file_contents.py
@@ -11,7 +11,8 @@ def setup_workflow(yaml_file):
 def run_workflow(yaml_file):
     workflow = setup_workflow(yaml_file)
     report = workflow.format_failure_report()
-    print(report)
+    if report:
+        print(report)
 
 
 def define_command_arg_parser():

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/data_for_md5sum_tests.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/data_for_md5sum_tests.py
@@ -1,0 +1,5 @@
+import hashlib
+
+
+def empty_md5():
+    return hashlib.md5("".encode("utf-8")).hexdigest()

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validate_file_contents.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validate_file_contents.py
@@ -1,0 +1,31 @@
+import sh
+
+from textwrap import dedent
+from pytest_mock import mocker
+
+from buddy.validate_file_contents import run_workflow
+from tests.integration_tests.data_for_md5sum_tests import empty_md5
+
+
+# The program
+# .. should not print anything if all validation tests pass
+
+
+class TestMd5sumWorkflow(object):
+    def test_nothing_printed_when_all_tests_pass(self, tmpdir, mocker):
+        yaml = dedent(
+            """
+            test1:
+                input_file: empty_file
+                expected_md5sum: {}
+            """
+        ).format(empty_md5())
+
+        with sh.pushd(tmpdir):
+            sh.touch("empty_file")
+            with open("config.yaml", "w") as f:
+                print(yaml, file=f)
+
+            mocker.patch("builtins.print")
+            run_workflow("config.yaml")
+            print.assert_not_called()

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validation_classes.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validation_classes.py
@@ -1,18 +1,16 @@
-import hashlib
-
 import pytest
 import sh
 
 from buddy.validation_classes import get_md5sum
+from tests.integration_tests.data_for_md5sum_tests import empty_md5
 
-# user can compare the md5sum of a file to a reference
+# user
+# .. can compare the md5sum of a file to a reference
 
 
 class TestMd5sum(object):
     def test_md5sum_for_existing_files(self, tmpdir):
         with sh.pushd(tmpdir):
-            empty_string_md5 = hashlib.md5("".encode("utf-8")).hexdigest()
-
             f_empty = "empty_file"
             f_non_empty = "non_empty_file"
 
@@ -21,8 +19,8 @@ class TestMd5sum(object):
                 print("some-data", file=f)
 
             assert isinstance(get_md5sum(f_empty), str)
-            assert get_md5sum(f_empty) == empty_string_md5
-            assert get_md5sum(f_non_empty) != empty_string_md5
+            assert get_md5sum(f_empty) == empty_md5()
+            assert get_md5sum(f_non_empty) != empty_md5()
         pass
 
     def test_md5sum_fails_for_file_objects(self, tmpdir):


### PR DESCRIPTION
`run_workflow` now prints the report only if it is a non-empty string.
So the validation program should not print anything to the command line if all
tests pass.