### PR TITLE
fix #50 : md5-match on comment-stripped files

### DIFF
--- a/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_classes.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_classes.py
@@ -1,31 +1,48 @@
-import os
-import sh
+import hashlib
 
 
 class Md5sumValidator:
-    def __init__(self, test_name, input_file, expected_md5sum):
+    def __init__(self, test_name, input_file, expected_md5sum, comment=None):
         self.test_name = test_name
         self.input_file = input_file
         self.expected_md5sum = expected_md5sum
         self.test_type = "md5sum"
+        self.comment = comment
 
     def is_valid(self):
-        return get_md5sum(self.input_file) == self.expected_md5sum
+        return get_md5sum(self.input_file, self.comment) == self.expected_md5sum
 
     def __eq__(self, other):
         return (
             self.test_name == other.test_name
             and self.input_file == other.input_file
             and self.expected_md5sum == other.expected_md5sum
+            and self.comment == other.comment
         )
 
 
-def get_md5sum(filepath):
+def get_md5sum(filepath, comment=None):
+    """
+    Compute the md5 sum for a file.
+    If `comment` is specified, ignore all lines of the file that start with
+    this comment-character.
+
+    :param filepath: a path to a file, a string.
+    :param comment: the comment character for the file; all lines that start
+    with this character will be disregarded.
+
+    :return: the md5sum for the file, as a string
+    """
+    my_predicate = lambda x: True
+    if comment is not None:
+        my_predicate = lambda x: not x.startswith(comment)
+
     try:
-        md5 = str(sh.md5sum(filepath)).strip().split()[0]
-        return md5
-    except sh.ErrorReturnCode:
-        if isinstance(filepath, str) and not os.path.isfile(filepath):
-            raise FileNotFoundError(filepath)
-        else:
-            raise
+        my_hash = hashlib.md5()
+        with open(filepath, "r") as f:
+            for line in filter(my_predicate, f):
+                my_hash.update(line.encode("utf-8"))
+    except:
+        raise
+
+    return my_hash.hexdigest()

--- a/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_workflow.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/buddy/validation_workflow.py
@@ -71,12 +71,7 @@ class ValidationWorkflow:
         """
 
         validators = {
-            k: Md5sumValidator(
-                input_file=v["input_file"],
-                test_name=k,
-                expected_md5sum=v["expected_md5sum"],
-            )
-            for k, v in yaml_dictionary.items()
+            k: Md5sumValidator(test_name=k, **v) for k, v in yaml_dictionary.items()
         }
 
         return validators

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validation_classes.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_validation_classes.py
@@ -36,3 +36,13 @@ class TestMd5sum(object):
             f0 = "missing_file"
             with pytest.raises(FileNotFoundError):
                 get_md5sum(f0)
+
+
+class TestMd5sumOnSubsetOfFile(object):
+    def test_comment_only_file_has_empty_md5sum(self, tmpdir):
+        with sh.pushd(tmpdir):
+            f_comment = "comment_file"
+            with open(f_comment, mode="w") as f:
+                print("# comment line", file=f)
+
+            assert get_md5sum(f_comment, comment="#") == empty_md5()

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/unit_tests/test_validation_workflow.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/unit_tests/test_validation_workflow.py
@@ -101,7 +101,7 @@ class TestGetFailingValidators(object):
         assert {} == workflow.get_failing_validators()
 
     def test_all_passing_validators_means_no_failures(self, monkeypatch):
-        def mock_md5sum(filepath):
+        def mock_md5sum(filepath, comment=None):
             return "a" * 32
 
         monkeypatch.setattr(buddy.validation_classes, "get_md5sum", mock_md5sum)
@@ -111,7 +111,7 @@ class TestGetFailingValidators(object):
         assert {} == workflow.get_failing_validators()
 
     def test_all_failing_validators(self, monkeypatch):
-        def mock_md5sum(filepath):
+        def mock_md5sum(filepath, comment=None):
             return "b" * 32
 
         monkeypatch.setattr(buddy.validation_classes, "get_md5sum", mock_md5sum)
@@ -125,7 +125,7 @@ class TestValidationReportFormatting(object):
     def test_all_passing_means_no_report(self, monkeypatch):
         # returns a string
         # lines are of form "test_name:XYZ\ttest_type:md5sum\tinput_file:ABC"
-        def mock_md5sum(filepath):
+        def mock_md5sum(filepath, comment=None):
             return "a" * 32
 
         monkeypatch.setattr(buddy.validation_classes, "get_md5sum", mock_md5sum)
@@ -135,7 +135,7 @@ class TestValidationReportFormatting(object):
         assert "" == workflow.format_failure_report()
 
     def test_all_failing_gives_report(self, monkeypatch):
-        def mock_md5sum(filepath):
+        def mock_md5sum(filepath, comment=None):
             return "b" * 32
 
         monkeypatch.setattr(buddy.validation_classes, "get_md5sum", mock_md5sum)
@@ -158,6 +158,11 @@ class TestParseValidatorDetails(object):
         yaml_dict = {
             "test1": {"input_file": "some_file", "expected_md5sum": "a" * 32},
             "test2": {"input_file": "another_file", "expected_md5sum": "b" * 32},
+            "test3": {
+                "input_file": "file_x",
+                "expected_md5sum": "c" * 32,
+                "comment": "#",
+            },
         }
 
         expected_validators = {
@@ -166,6 +171,12 @@ class TestParseValidatorDetails(object):
             ),
             "test2": Md5sumValidator(
                 test_name="test2", input_file="another_file", expected_md5sum="b" * 32
+            ),
+            "test3": Md5sumValidator(
+                test_name="test3",
+                input_file="file_x",
+                expected_md5sum="c" * 32,
+                comment="#",
             ),
         }
         validators = ValidationWorkflow.parse_validator_details(yaml_dict)


### PR DESCRIPTION
In one of my projects (`dtg_rnaseq`) I found that results files may be identical
modulo a comment line. For example, trimmed-down featureCounts files may have a
slightly different header (due to using a different version of `subread`) but
have identical read-counts. I want my results validation tests to permit
matching subsets of input files (eg, after filtering comments out; after
keeping only the first 100 lines etc).

`Md5sumValidator` and `get_md5sum` were modified: user can provide a `comment`
character. If this is not None, any lines with a comment-prefix will be
filtered out before computing the md5sum for the file.