### PR TITLE
fix #56 : add sidekick softlink using a hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,3 @@
+import os
+
+os.symlink("./bin/sidekick.py", "./sidekick")

--- a/{{cookiecutter.project_name}}/sidekick
+++ b/{{cookiecutter.project_name}}/sidekick
@@ -1,1 +1,0 @@
-bin/sidekick.py


### PR DESCRIPTION
Previous version of `data_buddy` had a bug where the requested softlink to sidekick.py was not present in an initialised project (an actual copy of the `sidekick` code was put in place)