### PR TITLE
fix #49 : add checks for package dir and R packaging script

### DIFF
--- a/{{cookiecutter.project_name}}/lib/Makefile
+++ b/{{cookiecutter.project_name}}/lib/Makefile
@@ -122,6 +122,7 @@ built_packages/${pkgname}_0.0.0.9000.tar.gz: \
 	Rscript -e 'library(devtools); library(methods);' \
                 -e 'setwd("${pkgname}");' \
                 -e 'document();' \
+                -e 'dir.create("../built_packages", showWarnings = FALSE);' \
                 -e 'devtools::build(path = "../built_packages")'
 
 ###############################################################################


### PR DESCRIPTION
check that build_packages R script is available before calling it

create `lib/built_packages` if it doesn't exist within Makefile

and create `lib/build_packages` within setup_libs.sh if a
cloned or copied package is built

Also use "${LIB_DIR}" rather than "./lib" throughout