### PR TITLE
create & validate symlinks using `buddy`

### DIFF
--- a/{{cookiecutter.project_name}}/bin/buddy/buddy/make_symlink.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/buddy/make_symlink.py
@@ -1,0 +1,62 @@
+"""
+Functions to make links from one file location (link) to another (target)
+"""
+
+import argparse
+import errno
+import os
+import os.path
+import sys
+
+
+def add_relative_symlink(target, link):
+    """
+    Create a symbolic link from `link` to `target`.
+
+    Pass-through if the link exists and already points to target.
+    Ensure the target is referred to relative to the link location
+    and make any intervening directories.
+
+    Throw errors if:
+    - target does not exist
+    - link already exists and is not a link
+    - link exists but does not point to target
+
+    :param target: An existing file/dir/link on the filesystem
+    :param link: A filepath; a softlink from this location to
+      `target` will be made.
+    :return: Null
+    """
+
+    if not os.path.exists(target):
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), target)
+
+    try:
+        dname = os.path.dirname(link)
+        if dname and not os.path.isdir(dname):
+            os.makedirs(dname, exist_ok=True)
+        relative_target_path = os.path.relpath(target, start=dname)
+        os.symlink(relative_target_path, link)
+    except FileExistsError as err:
+        if not os.path.islink(link):
+            print("Attempt to convert a file to a link", file=sys.stderr)
+            raise err
+        if os.readlink(link) != relative_target_path:
+            print("Attempt to rewrite a link", file=sys.stderr)
+            raise err
+
+
+def define_command_arg_parser():
+    """
+    Get a parser that extracts the command args used when calling this
+    program
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target", nargs=1)
+    parser.add_argument("link", nargs=1)
+    return parser
+
+
+if __name__ == "__main__":
+    ARGS = define_command_arg_parser().parse_args()
+    add_relative_symlink(ARGS.target[0], ARGS.link[0])

--- a/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_make_symlink.py
+++ b/{{cookiecutter.project_name}}/bin/buddy/tests/integration_tests/test_make_symlink.py
@@ -1,0 +1,101 @@
+import os
+import os.path
+import pytest
+import sh
+
+from buddy.make_symlink import add_relative_symlink
+
+
+class TestLinkMaker(object):
+    def test_make_fresh_link(self, tmpdir):
+        # - make a temp dir
+        # - add a file
+        # - use make_soft_link to make a link to that file from a previously
+        # non-existing location
+        target = "abc.txt"
+        link = "abc.link"
+        with sh.pushd(tmpdir):
+            sh.touch(target)
+            add_relative_symlink(target, link)
+            assert os.path.islink(link)
+            assert os.readlink(link) == target
+
+    def test_dont_throw_error_if_link_points_to_target(self, tmpdir, mocker):
+        # - make a temp dir
+        # - add a file
+        # - make a soft link to that file from a link-name
+        # - use make_soft_link to make a link to that file from the same link-name
+        # - check that the second call did not call os.symlink
+        target = "abc.txt"
+        link = "abc.link"
+        with sh.pushd(tmpdir):
+            sh.touch(target)
+            add_relative_symlink(target, link)
+            add_relative_symlink(target, link)
+            assert os.path.islink(link)
+            assert os.readlink(link) == target
+
+    def test_throw_error_if_rewriting_link(self, tmpdir, mocker):
+        # - make a temp dir
+        # - add two files
+        # - make a soft link to one file
+        # - attempt to make the link point to the other file
+        # - check that the second call throws an error
+        target1 = "abc.txt"
+        target2 = "def.txt"
+        link = "abc.link"
+        with sh.pushd(tmpdir):
+            sh.touch(target1)
+            sh.touch(target2)
+            add_relative_symlink(target1, link)
+            with pytest.raises(FileExistsError):
+                add_relative_symlink(target2, link)
+
+    def test_correct_relative_paths(self, tmpdir):
+        # - make a tempdir
+        # - add two directories A and B
+        # - add a file to A
+        # - make a link to A/the_file from in B using python
+        # - make a link to A/the_file from in B using relative paths in sh
+        # - test that the the two links have the same representation
+        with sh.pushd(tmpdir):
+            sh.mkdir("A")
+            sh.mkdir("B")
+            target = "A/some_file"
+            sh.touch(target)
+            link1 = "B/link1"
+            link2 = "B/link2"
+            add_relative_symlink(target, link1)
+            sh.ln("--symbolic", "--relative", target, link2)
+            assert os.readlink(link1) == os.readlink(link2)
+
+    def test_error_if_linkloc_exists_but_is_not_a_link(self, tmpdir):
+        # - make a tempdir
+        # - add two files
+        # - make a link from one file to the other
+        # - making the link should fail since a (non-link) file exists at the
+        # link location
+        with sh.pushd(tmpdir):
+            sh.touch("a.txt")
+            sh.touch("b.txt")
+            with pytest.raises(FileExistsError):
+                add_relative_symlink("a.txt", "b.txt")
+
+    def test_subdir_is_made_when_subdir_doesnt_exist(self, tmpdir):
+        # - make a tempdir
+        # - add a file
+        # - make a link from a location in a non-existing subdir to the file
+        with sh.pushd(tmpdir):
+            sh.touch("a.txt")
+            link = "subdir/b.txt"
+            add_relative_symlink("a.txt", link)
+            assert os.path.islink(link)
+            assert os.readlink(link) == "../a.txt"
+
+    def test_error_if_target_is_missing(self, tmpdir):
+        # - make a tempdir
+        # - attempt to make a link from a file to another (nonexisting) file
+        # - error should be thrown
+        with sh.pushd(tmpdir):
+            with pytest.raises(FileNotFoundError):
+                add_relative_symlink("doesnt_exist.txt", "some_link")

--- a/{{cookiecutter.project_name}}/scripts/helpers_for_setup/setup_dirs.sh
+++ b/{{cookiecutter.project_name}}/scripts/helpers_for_setup/setup_dirs.sh
@@ -176,23 +176,14 @@ do
   TARGET=$( expand_tilde "${ARY[0]}"  )
   LINKNAME=$( expand_tilde "${ARY[1]}" )
 
-  # Check that the target is an existing file/dir or a link and die if not
-  if [[ ! -f "${TARGET}" ]] && \
-     [[ ! -d "${TARGET}" ]] && \
-     [[ ! -L "${TARGET}" ]];
-  then
-    die_and_moan \
-    "${0}: target ${TARGET} isn't an existing dir/file/link"
-  fi
+  # TODO: convert make_soft_links.py to a .yaml-parsing workflow then rewrite
+  # the above code - calling the script with a .yaml as input.
 
+  # The target should be an existing file/dir or a link
+  #
   # The directory in which the link is to be placed should be made if it
   #   doesn't exist
-  LINKDIR=$(dirname  "${LINKNAME}")
-  if [[ ! -d "${LINKDIR}" ]];
-  then
-    mkdir -p "${LINKDIR}"
-  fi
-
+  #
   # If the link path is already in use, it must be a link and point to the
   # the same path as stored in TARGET
   #
@@ -212,26 +203,9 @@ do
   # link and the intended target. This allows us to link to a filepath that is
   # also a link.
   #
-  if [[ -e "${LINKNAME}" ]] || \
-     [[ -L "${LINKNAME}" ]];
-  then
-    if [[ ! -L "${LINKNAME}" ]];
-    then
-      die_and_moan \
-      "${0}: intended link ${LINKNAME} already exists but is not a link"
-    fi
-    if [[ "$(readlink -f ${LINKNAME})" != "$(readlink -f ${TARGET})" ]];
-    then
-      die_and_moan \
-      "${0}: intended link ${LINKNAME} already exists and points to a \
-      \n different location than planned"
-    fi
-  else
-    ln --symbolic \
-       --relative \
-       "${TARGET}" \
-       "${LINKNAME}"
-  fi
+  MAKE_LINK_SCRIPT="${BUDDY_PY}/buddy/make_symlink.py"
+  python3 ${MAKE_LINK_SCRIPT} ${TARGET} ${LINKNAME}
+
 done < "${MAKE_LINKS_FILE}"
 
 ###############################################################################


### PR DESCRIPTION
Moved creation of symlinks from `setup_dirs.sh` into `buddy` so that
I could test.

Function `add_relative_symlink` creates symlink from link to target
provided target exists and link does not already exist (unless link
exists but is not a link).

Any intervening directories are made, and the links are made
relative to the directory that `link` is placed in.

Rewrote part of the `scripts/helpers.../setup_dirs.sh` to use the
symlinks function within `buddy`.

Can be used as CLI script `python3 <script> <target> <linkname>`